### PR TITLE
Don't override ternProjectDir if already set in vimrc.

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -507,7 +507,9 @@ function! tern#Enable()
   if stridx(&buftype, "nofile") > -1 || stridx(&buftype, "nowrite") > -1
     return
   endif
-  let b:ternProjectDir = ''
+  if !exists("b:ternProjectDir")
+    let b:ternProjectDir = ''
+  endif
   let b:ternLastCompletion = []
   let b:ternLastCompletionPos = {'row': -1, 'start': 0, 'end': 0}
   let b:ternBufferSentAt = -1


### PR DESCRIPTION
The function term#Enable overrides the value of ternProjectDir. In some
cases we would need to allow to customize this value, for instance
working with multiple projects that have similar conditions where we
don't want to create a new .term-project file for every project.

With this change, we can define a custom .term-project file in .vimrc that
will be applied to every project.