### PR TITLE
Redirect TernDocBrowse output to devnull

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -289,7 +289,15 @@ def tern_lookupDocumentation(browse=False):
   doc = data.get("doc")
   url = data.get("url")
   if url:
-    if browse: return webbrowser.open(url)
+    if browse: 
+      savout = os.dup(1)
+      os.close(1)
+      os.open(os.devnull, os.O_RDWR)
+      try:
+        result = webbrowser.open(url)
+      finally:
+        os.dup2(savout, 1)
+        return result
     doc = ((doc and doc + "\n\n") or "") + "See " + url
   if doc:
     vim.command("call tern#PreviewInfo(" + json.dumps(doc) + ")")


### PR DESCRIPTION
Whenever I opened the documentation with my browser I ended up receiving the stderr / stdio of Chromium inside vim. This fix temporarily redirects the output to /dev/null.

Before:
![Before](http://i.imgur.com/xcKmXFE.png?1)

After using :TernDocBrowse
![After](http://i.imgur.com/Rc75Msq.png?1)

Obviously my Chromium has seen better days, but no matter the length of the message it is still annoying:
![After2](http://i.imgur.com/nFRX90u.png?1)