### PR TITLE
Fix 'ascii' codec can't encode character u'\u2716' when tern_show_arg…

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -311,7 +311,7 @@ def tern_echoWrap(data, name=""):
   col = int(vim.eval("&columns"))-23
   if len(text) > col:
     text = text[0:col]+"..."
-  vim.command("echo '{0}'".format(text))
+  vim.command("echo '{0}'".format(text.encode('utf-8')))
 
 def tern_lookupType():
   data = tern_runCommand("type")


### PR DESCRIPTION
When I use show argument hint feature.
I will see this error message.

	Traceback (most recent call last):
	  File "<string>", line 1, in <module>
	  File "/Users/othree/.vim/bundle/tern_for_vim/script/tern.py", line 318, in tern_lookupType
	    if data: tern_echoWrap(data.get("type", ""))
	  File "/Users/othree/.vim/bundle/tern_for_vim/script/tern.py", line 314, in tern_echoWrap
	    vim.command("echo '{0}'".format(text))
	UnicodeEncodeError: 'ascii' codec can't encode character u'\u2716' in position 3: ordinal not in range(128)

The reason is the cross sign.

![2015-07-09 6 25 55](https://cloud.githubusercontent.com/assets/16474/8593259/b05e53b4-2668-11e5-8b1c-ea99e1dd8ee9.png)
 